### PR TITLE
Adds onInit mixin for use in controllers.

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -5,12 +5,14 @@ import EKMixin from 'ember-keyboard/mixins/ember-keyboard';
 import EKFirstResponderOnFocusMixin from 'ember-keyboard/mixins/keyboard-first-responder-on-focus';
 import EKOnFocusMixin from 'ember-keyboard/mixins/activate-keyboard-on-focus';
 import EKOnInsertMixin from 'ember-keyboard/mixins/activate-keyboard-on-insert';
+import EKOnInitMixin from 'ember-keyboard/mixins/activate-keyboard-on-init';
 
 export {
   EKMixin,
   EKFirstResponderOnFocusMixin,
   EKOnFocusMixin,
   EKOnInsertMixin,
+	EKOnInitMixin,
   getCode,
   getKeyCode,
   getMouseCode

--- a/addon/mixins/activate-keyboard-on-init.js
+++ b/addon/mixins/activate-keyboard-on-init.js
@@ -1,0 +1,9 @@
+import Mixin from '@ember/object/mixin';
+import { on } from '@ember/object/evented';
+import { set } from '@ember/object';
+
+export default Mixin.create({
+  activateKeyboardWhenStarted: on('init', function() {
+    set(this, 'keyboardActivated', true);
+  })
+});

--- a/tests/dummy/app/templates/mixins.hbs
+++ b/tests/dummy/app/templates/mixins.hbs
@@ -11,6 +11,12 @@ To reduce boilerplate, `ember-keyboard` includes several mixins with common patt
 
 This mixin will activate the component on `didInsertElement`, and as per normal, it will deactivate on `willDestroyElement`.
 
+### EKOnInitMixin
+
+`import { EKOnInitMixin } from 'ember-keyboard';`
+
+This mixin will activate the controller on `init`.
+
 ### EKOnFocusMixin
 
 `import { EKOnFocusMixin } from 'ember-keyboard';`


### PR DESCRIPTION
This reduces boilerplate just like onInsert and the other helper mixins. Just this time for controllers. Controllers aren't dead, long live controllers.